### PR TITLE
Bump requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pressbooks SAML2 Single Sign-On 
 **Contributors:** conner_bw, greatislander  
 **Tags:** pressbooks, saml, saml2, sso, shibboleth  
-**Requires at least:** 5.0.3  
-**Tested up to:** 5.0.3  
+**Requires at least:** 5.1.0  
+**Tested up to:** 5.1.0  
 **Requires PHP:** 7.1  
 **Stable tag:** 1.0.0  
 **License:** GPLv3 or later  
@@ -91,10 +91,11 @@ Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/one
 
 
 ### 1.0.0 
-+ Renamed & refactored plugin to clarify focus (was pressbooks-shibboleth-sso, is now pressbooks-saml-sso)
-+ Fix infinite redirects when using ADFS
-+ Bump onelogin/php-saml from dev-master to 3.1.0
-+ Fix GitHub Updater
++ Rename plugin
++ Works with non-federated Shibboleth, Microsoft ADFS, and Google Apps.
++ Refactor code to respect Pressbooks coding standards 1.0.0
++ Fix an issue with GitHub updater not always working
++ Update dependencies to latest versions
 
 
 ### 0.0.5 
@@ -126,4 +127,4 @@ Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/one
 
 
 ### 1.0.0 
-* Pressbooks SAML2 Single Sign-On requires Pressbooks >= 5.6.5 and WordPress >= 5.0.3
+* Pressbooks SAML2 Single Sign-On requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0

--- a/pressbooks-saml-sso.php
+++ b/pressbooks-saml-sso.php
@@ -6,7 +6,7 @@ Description: SAML2 Single Sign-On integration for Pressbooks. (Shibboleth, Micro
 Version: 1.0.0
 Author: Pressbooks (Book Oven Inc.)
 Author URI: https://pressbooks.org
-Pressbooks tested up to: 5.6.5
+Pressbooks tested up to: 5.7.0
 Text Domain: pressbooks-saml-sso
 License: GPL v3 or later
 Network: True

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Pressbooks SAML2 Single Sign-On ===
 Contributors: conner_bw, greatislander
 Tags: pressbooks, saml, saml2, sso, shibboleth
-Requires at least: 5.0.3
-Tested up to: 5.0.3
+Requires at least: 5.1.0
+Tested up to: 5.1.0
 Requires PHP: 7.1
 Stable tag: 1.0.0
 License: GPLv3 or later
@@ -84,10 +84,11 @@ Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/one
 == Changelog ==
 
 = 1.0.0 =
-+ Renamed & refactored plugin to clarify focus (was pressbooks-shibboleth-sso, is now pressbooks-saml-sso)
-+ Fix infinite redirects when using ADFS
-+ Bump onelogin/php-saml from dev-master to 3.1.0
-+ Fix GitHub Updater
++ Rename plugin
++ Works with non-federated Shibboleth, Microsoft ADFS, and Google Apps.
++ Refactor code to respect Pressbooks coding standards 1.0.0
++ Fix an issue with GitHub updater not always working
++ Update dependencies to latest versions
 
 = 0.0.5 =
 **Patches**
@@ -112,4 +113,4 @@ Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/one
 == Upgrade Notice ==
 
 = 1.0.0 =
-* Pressbooks SAML2 Single Sign-On requires Pressbooks >= 5.6.5 and WordPress >= 5.0.3
+* Pressbooks SAML2 Single Sign-On requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0


### PR DESCRIPTION
Pressbooks SAML2 Single Sign-On requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0