### PR TITLE
Fix: SAML login from a book URL

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -21,7 +21,8 @@ function login_url() {
 	if ( is_subdomain_install() ) {
 		$login_url = network_site_url( '/wp-login.php' );
 	} else {
-		$login_url = wp_login_url();
+		$login_url = get_site_url( 1, 'wp-login.php', 'login' );
+		$login_url = apply_filters( 'login_url', $login_url, '', false );
 	}
 	$login_url = add_query_arg( 'action', SAML::LOGIN_PREFIX, $login_url );
 	$login_url = \Pressbooks\Sanitize\maybe_https( $login_url );


### PR DESCRIPTION
When I test with: https://samltest.id/

If I initiate a login from:
https://pressbooks.test/wp-login.php
It works.

If I initiate a login from:
https://pressbooks.test/theprince/wp-login.php
It does not work.

This PR fixes it.