### PR TITLE
Use SAML standard attributes name, instead of friendly names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ branches:
   - dev
   - "/\\d+\\.\\d+(\\.\\d+)?(-\\S*)?$/"
 php:
-- 7.1
-- 7.2
 - 7.3
 env:
 - WP_VERSION=latest WP_MULTISITE=1 TRAVIS_NODE_VERSION="10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ cache:
   - vendor
 before_install:
 - source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION && nvm use $TRAVIS_NODE_VERSION
+- composer self-update 1.10.17
 install:
 - node -v
 - npm install

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -450,11 +450,8 @@ class SAML {
 	public function parseAttributeStatement() {
 		// Attributes
 		$attributes = $this->auth->getAttributes();
-		if (
-			! isset( $attributes[ self::SAML_MAP_FIELDS['uid'] ] ) ||
-			! isset( $attributes[ self::SAML_MAP_FIELDS['mail'] ] )
-		) {
-			throw new \Exception( __( 'Missing SAML attributes: uid, mail', 'pressbooks-saml-sso' ) );
+		if ( ! isset( $attributes[ self::SAML_MAP_FIELDS['uid'] ] ) ) {
+			throw new \Exception( __( 'Missing SAML urn:oid:0.9.2342.19200300.100.1.1 attribute', 'pressbooks-saml-sso' ) );
 		}
 		return $attributes;
 	}

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -75,11 +75,11 @@ class SamlTest extends \WP_UnitTestCase {
 			->method( 'isAuthenticated' )
 			->willReturn( true );
 		$stub1
-			->method( 'getAttributesWithFriendlyName' )
+			->method( 'getAttributes' )
 			->willReturn(
 				[
-					'uid' => [ 'uid' ],
-					'mail' => [ 'uid@pressbooks.test' ],
+					$this->saml::SAML_MAP_FIELDS['uid'] => [ 'uid' ],
+					$this->saml::SAML_MAP_FIELDS['mail'] => [ 'uid@pressbooks.test' ],
 				]
 			);
 
@@ -95,8 +95,8 @@ class SamlTest extends \WP_UnitTestCase {
 			->method( 'getAttributes' )
 			->willReturn(
 				[
-					'uid' => [ 'adfs' ],
-					'mail' => [ 'adfs@pressbooks.test' ],
+					$this->saml::SAML_MAP_FIELDS['uid'] => [ 'adfs' ],
+					$this->saml::SAML_MAP_FIELDS['mail'] => [ 'adfs@pressbooks.test' ],
 				]
 			);
 		return $stub1;
@@ -234,8 +234,8 @@ class SamlTest extends \WP_UnitTestCase {
 		unset( $_POST['SAMLResponse'] );
 		$this->saml->setAuth( $this->getMockAuthForAcs() );
 		$this->saml->samlAssertionConsumerService();
-		$this->assertEquals( $_SESSION['pb_saml_user_data']['uid'][0], 'uid' );
-		$this->assertEquals( $_SESSION['pb_saml_user_data']['mail'][0], 'uid@pressbooks.test' );
+		$this->assertEquals( $_SESSION['pb_saml_user_data'][ $this->saml::SAML_MAP_FIELDS['uid'] ][0], 'uid' );
+		$this->assertEquals( $_SESSION['pb_saml_user_data'][ $this->saml::SAML_MAP_FIELDS['mail'] ][0], 'uid@pressbooks.test' );
 	}
 
 	public function test_parseAttributeStatement() {
@@ -247,8 +247,8 @@ class SamlTest extends \WP_UnitTestCase {
 
 		$this->saml->setAuth( $this->getMockAuthForAttributes() );
 		$attr = $this->saml->parseAttributeStatement();
-		$this->assertEquals( $attr['uid'][0], 'adfs' );
-		$this->assertEquals( $attr['mail'][0], 'adfs@pressbooks.test' );
+		$this->assertEquals( $attr[ $this->saml::SAML_MAP_FIELDS['uid'] ][0], 'adfs' );
+		$this->assertEquals( $attr[ $this->saml::SAML_MAP_FIELDS['mail'] ][0], 'adfs@pressbooks.test' );
 	}
 
 	// TODO
@@ -313,8 +313,8 @@ class SamlTest extends \WP_UnitTestCase {
 
 		// Try to find the user and succeed thanks to fallback eduPersonPrincipalName info in the session
 		$_SESSION[ \PressbooksSamlSso\SAML::USER_DATA ] = [
-			'mail' => [ 'one@pressbooks.test', 'two@pressbooks.test' ],
-			'eduPersonPrincipalName' => [ 'three@pressbooks.test', $email ],
+			$this->saml::SAML_MAP_FIELDS['mail'] => [ 'one@pressbooks.test', 'two@pressbooks.test' ],
+			$this->saml::SAML_MAP_FIELDS['eduPersonPrincipalName'] => [ 'three@pressbooks.test', $email ],
 		];
 		$user = $this->saml->findExistingUser( 'nobody@pressbooks.test' );
 		$this->assertInstanceOf( '\WP_User', $user );

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -214,6 +214,16 @@ class SamlTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result->get_error_message(), 'Mock object was here' );
 	}
 
+	public function test_authenticate_session() {
+		$_SESSION['pb_saml_user_data'] = [
+			$this->saml::SAML_MAP_FIELDS['uid'] => [ 'uid' ],
+			$this->saml::SAML_MAP_FIELDS['mail'] => [ 'uid@pressbooks.test' ],
+		];
+		ob_start();
+		$result = $this->saml->authenticate( null, 'test', 'test' );
+		$this->assertInstanceOf( '\WP_Error', $result );
+	}
+
 	public function test_samlMetadata() {
 		ob_start();
 		$this->saml->samlMetadata();

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -252,7 +252,7 @@ class SamlTest extends \WP_UnitTestCase {
 		try {
 			$this->saml->parseAttributeStatement();
 		} catch ( Exception $e ) {
-			$this->assertContains( 'Missing SAML attributes', $e->getMessage() );
+			$this->assertContains( 'Missing SAML', $e->getMessage() );
 		}
 
 		$this->saml->setAuth( $this->getMockAuthForAttributes() );


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks-saml-sso/issues/50

This change avoid the friendly names for SAML attributes, but uses the standard ones. 
A new constant with friendly names and standard ones was created to use within tie SAML class, in that way the attributes are handled using friendly names but stored in the session with standard convention.

### How to test
Login through SAML in Pressbooks. It should works just like before.