### PR TITLE
Improve get email flow

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -187,6 +187,24 @@ class SAML {
 		return true;
 	}
 
+	/**
+	 * @param array $net_id
+	 * @param array $attributes
+	 *
+	 * @return string
+	 */
+	public function getEmail( $net_id, $attributes ) {
+		if ( isset( $attributes[ self::SAML_MAP_FIELDS['mail'] ][0] ) ) {
+			$email = $attributes[ self::SAML_MAP_FIELDS['mail'] ][0];
+		}
+		elseif ( isset ( $attributes[ self::SAML_MAP_FIELDS['eduPersonPrincipalName'] ][0] ) ) {
+			$email = $attributes[ self::SAML_MAP_FIELDS['eduPersonPrincipalName'] ][0];
+		}
+		else {
+			$email = "{$net_id}@127.0.0.1";
+		}
+		return $email;
+	}
 
 	/**
 	 * @return array
@@ -338,7 +356,7 @@ class SAML {
 							ob_end_clean();
 							$attributes = $_SESSION[ self::USER_DATA ];
 							$net_id = $attributes[ self::SAML_MAP_FIELDS['uid'] ][0];
-							$email = isset( $attributes[ self::SAML_MAP_FIELDS['mail'] ][0] ) ? $attributes[ self::SAML_MAP_FIELDS['mail'] ][0] : "{$net_id}@127.0.0.1";
+							$email = getEmail( $net_id, $attributes);
 							remove_filter( 'authenticate', [ $this, 'authenticate' ], 10 ); // Fix infinite loop
 							/**
 							 * @since 0.0.4

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -188,25 +188,6 @@ class SAML {
 	}
 
 	/**
-	 * @param array $net_id
-	 * @param array $attributes
-	 *
-	 * @return string
-	 */
-	public function getEmail( $net_id, $attributes ) {
-		if ( isset( $attributes[ self::SAML_MAP_FIELDS['mail'] ][0] ) ) {
-			$email = $attributes[ self::SAML_MAP_FIELDS['mail'] ][0];
-		}
-		elseif ( isset ( $attributes[ self::SAML_MAP_FIELDS['eduPersonPrincipalName'] ][0] ) ) {
-			$email = $attributes[ self::SAML_MAP_FIELDS['eduPersonPrincipalName'] ][0];
-		}
-		else {
-			$email = "{$net_id}@127.0.0.1";
-		}
-		return $email;
-	}
-
-	/**
 	 * @return array
 	 */
 	public function getSamlSettings() {
@@ -722,6 +703,25 @@ class SAML {
 		remove_user_from_blog( $user_id, 1 );
 
 		return [ $user_id, $username ];
+	}
+
+	/**
+	 * @param string $net_id
+	 * @param array $attributes
+	 *
+	 * @return string
+	 */
+	public function getEmail( $net_id, $attributes ) {
+		if ( isset( $attributes[ self::SAML_MAP_FIELDS['mail'] ][0] ) ) {
+			$email = $attributes[ self::SAML_MAP_FIELDS['mail'] ][0];
+		}
+		elseif ( isset ( $attributes[ self::SAML_MAP_FIELDS['eduPersonPrincipalName'] ][0] ) ) {
+			$email = $attributes[ self::SAML_MAP_FIELDS['eduPersonPrincipalName'] ][0];
+		}
+		else {
+			$email = "{$net_id}@127.0.0.1";
+		}
+		return $email;
 	}
 
 	/**


### PR DESCRIPTION
One of our oldest clients has informed me that they're not sending us email values as `urn:oid:0.9.2342.19200300.100.1.3`. Rather they're sending ePPN (`urn:oid:1.3.6.1.4.1.5923.1.1.1.6`) but mapping it to the FriendlyName `mail`. I'd like to change the set $email flow so that the logic looks like this:
1. Try to find `urn:oid:0.9.2342.19200300.100.1.3` -- if it exists, use this as the new user's email address in Pressbooks. If it does not exist, then ...
2. Try to find `urn:oid:1.3.6.1.4.1.5923.1.1.1.6` (ePPN) -- if it exists use this as the new user's email address in Pressbooks. If it does not exist, then ...
3. Set the user's email address to `uid`@127.0.0.1. `uid` should be `urn:oid:0.9.2342.19200300.100.1.1` and will have already been set as the local variable $net_id

I'm trying to do that with this draft PR. I haven't written unit tests yet, and am not sure if I have the right array position declared for the mapped mail and ePPN attributes.