### PR TITLE
Add compatibility for friendly names

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -411,7 +411,7 @@ class SAML {
 	 */
 	public function getEmailByAttributes( $attributes, $net_id ) {
 		if ( isset( $attributes[ self::SAML_MAP_FIELDS['mail'] ] ) ) {
-			return $attributes[ self::SAML_MAP_FIELDS['mail'] ][0] ;
+			return $attributes[ self::SAML_MAP_FIELDS['mail'] ][0];
 		}
 		if ( isset( $attributes['friendlyAttributes']['mail'] ) ) {
 			return $attributes['friendlyAttributes']['mail'][0];

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -351,6 +351,15 @@ class SamlTest extends \WP_UnitTestCase {
 
 		$attributes = [
 			'nomail' => 'nomail@nomail.com',
+			$this->saml::SAML_MAP_FIELDS['eduPersonPrincipalName'] => [ 'fake_eppn@fake.com' ],
+			'friendlyAttributes' => [
+				'noMail' => [ 'fake_mail@fake.com' ],
+			],
+		];
+		$this->assertEquals( $this->saml->getEmailByAttributes( $attributes, 'fakeuid' ), 'fake_eppn@fake.com' );
+
+		$attributes = [
+			'nomail' => 'nomail@nomail.com',
 			'friendlyAttributes' => [
 				'noMail' => [ 'fake_mail@fake.com' ],
 			],

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -87,18 +87,26 @@ class SamlTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @param $attributes - Attributes to mock
 	 * @return \OneLogin\Saml2\Auth
 	 */
-	protected function getMockAuthForAttributes() {
+	protected function getMockAuthForAttributes( $attributes ) {
 		$stub1 = $this->getMockAuth();
 		$stub1
 			->method( 'getAttributes' )
-			->willReturn(
-				[
-					$this->saml::SAML_MAP_FIELDS['uid'] => [ 'adfs' ],
-					$this->saml::SAML_MAP_FIELDS['mail'] => [ 'adfs@pressbooks.test' ],
-				]
-			);
+			->willReturn( $attributes );
+		return $stub1;
+	}
+
+	/**
+	 * @param $attributes - Attributes to mock
+	 * @return \OneLogin\Saml2\Auth
+	 */
+	protected function getMockAuthForFriendlyAttributes( $attributes ) {
+		$stub1 = $this->getMockAuth();
+		$stub1
+			->method( 'getAttributesWithFriendlyName' )
+			->willReturn( $attributes );
 		return $stub1;
 	}
 
@@ -255,10 +263,99 @@ class SamlTest extends \WP_UnitTestCase {
 			$this->assertContains( 'Missing SAML', $e->getMessage() );
 		}
 
-		$this->saml->setAuth( $this->getMockAuthForAttributes() );
+		$mock_attributes = [
+			$this->saml::SAML_MAP_FIELDS['uid'] => [ 'adfs' ],
+			$this->saml::SAML_MAP_FIELDS['mail'] => [ 'adfs@pressbooks.test' ],
+		];
+		$this->saml->setAuth( $this->getMockAuthForAttributes( $mock_attributes ) );
 		$attr = $this->saml->parseAttributeStatement();
 		$this->assertEquals( $attr[ $this->saml::SAML_MAP_FIELDS['uid'] ][0], 'adfs' );
 		$this->assertEquals( $attr[ $this->saml::SAML_MAP_FIELDS['mail'] ][0], 'adfs@pressbooks.test' );
+	}
+
+	public function test_parseAttributeStatementFriendlyAttributes() {
+		$mock_attributes = [
+			'wrongUid' => [ 'Wrong UID Friendly' ],
+			'mail' => [ 'mailFriendly@pressbooks.test' ],
+		];
+		$this->saml->setAuth( $this->getMockAuthForAttributes( $mock_attributes ) );
+		try {
+			$this->saml->parseAttributeStatement();
+		} catch ( Exception $e ) {
+			$this->assertContains( 'Missing SAML', $e->getMessage() );
+		}
+
+		$mock_attributes = [
+			'uid' => [ 'fake_friendly_uid' ],
+		];
+		$this->saml->setAuth( $this->getMockAuthForFriendlyAttributes( $mock_attributes ) );
+		$attributes = $this->saml->parseAttributeStatement();
+		$this->assertEquals( $attributes['friendlyAttributes'][ 'uid' ][0], 'fake_friendly_uid' );
+
+		$mock_attributes = [
+			$this->saml::SAML_MAP_FIELDS['eduPersonPrincipalName'] => [ 'fake_eppn@fake.com' ]
+		];
+		$this->saml->setAuth( $this->getMockAuthForAttributes( $mock_attributes ) );
+		$attributes = $this->saml->parseAttributeStatement();
+		$this->assertEquals( $attributes[ $this->saml::SAML_MAP_FIELDS['eduPersonPrincipalName'] ][0], 'fake_eppn@fake.com' );
+	}
+
+	public function test_getUsernameByAttributes() {
+		$attributes = [
+			'nonuid' => ['novalue'],
+			'friendlyAttributes' => [],
+			$this->saml::SAML_MAP_FIELDS['eduPersonPrincipalName'] => [ 'fake_eppn@fake.com' ]
+		];
+		$this->assertEquals( $this->saml->getUsernameByAttributes( $attributes ), 'fake_eppn' );
+
+		$attributes = [
+			'nonuid' => ['novalue'],
+			'nonEduPersonPrincipalName' => [ 'novalue' ],
+			'friendlyAttributes' => [
+				'uid' => ['fake_uid'],
+			],
+		];
+		$this->assertEquals( $this->saml->getUsernameByAttributes( $attributes ), 'fake_uid' );
+
+		$attributes = [
+			$this->saml::SAML_MAP_FIELDS['uid'] => ['fake_uid'],
+			'nonEduPersonPrincipalName' => [ 'eppn@fake.com' ],
+			'friendlyAttributes' => [
+				'uid' => ['fake_uid_friendly'],
+			],
+		];
+		$this->assertEquals( $this->saml->getUsernameByAttributes( $attributes ), 'fake_uid' );
+		$attributes = [
+			'nonuid' => ['fake_uid'],
+			'nonEduPersonPrincipalName' => [ 'eppn@fake.com' ],
+			'friendlyAttributes' => [
+				'nonuid' => ['fake_uid_friendly'],
+			],
+		];
+		$this->assertFalse( $this->saml->getUsernameByAttributes( $attributes ) );
+	}
+
+	public function test_getEmailByAttributes() {
+		$attributes = [
+			'friendlyAttributes' => [],
+			$this->saml::SAML_MAP_FIELDS['mail'] => [ 'fake_mail@fake.com' ],
+		];
+		$this->assertEquals( $this->saml->getEmailByAttributes( $attributes, 'fakeuid' ), 'fake_mail@fake.com' );
+
+		$attributes = [
+			'friendlyAttributes' => [
+				'mail' => [ 'fake_mail@fake.com' ],
+			],
+		];
+		$this->assertEquals( $this->saml->getEmailByAttributes( $attributes, 'fakeuid' ), 'fake_mail@fake.com' );
+
+		$attributes = [
+			'nomail' => 'nomail@nomail.com',
+			'friendlyAttributes' => [
+				'noMail' => [ 'fake_mail@fake.com' ],
+			],
+		];
+		$this->assertEquals( $this->saml->getEmailByAttributes( $attributes, 'fakeuid' ), 'fakeuid@127.0.0.1' );
 	}
 
 	// TODO


### PR DESCRIPTION
One of our oldest clients has informed me that they're not sending us email values as `urn:oid:0.9.2342.19200300.100.1.3`. Rather they're sending ePPN (`urn:oid:1.3.6.1.4.1.5923.1.1.1.6`) but mapping it to the FriendlyName `mail`.
Also we'd like to change the set email flow.

This change implements the following logic for UID:

1. try to find `urn:oid:0.9.2342.19200300.100.1.1` -- if found, use that value
2. If not found, get FriendlyAttributes and try to find something with FriendlyName uid.
3. if not found, try to find `urn:oid:1.3.6.1.4.1.5923.1.1.1.6` (eppn) -- if found, split at the @ sign and use the string that comes before the @
4. If not found, return error telling them `urn:oid:0.9.2342.19200300.100.1.1` could not be found

For email:

1. try to find `urn:oid:0.9.2342.19200300.100.1.3` -- if found, use that value
2. if not found,  get FriendlyAttributes and try to find something with FriendlyName mail.
3. if not found, try to find `urn:oid:1.3.6.1.4.1.5923.1.1.1.6` (eppn) -- if found use this value as email address
4. if not found, set email to username + fake domain: `uid@127.0.0.1`