### PR TITLE
Include log module from pressbooks for log SAML data

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,34 @@ The email can be filtered, example: `add_filter( 'pb_integrations_multidomain_em
 
 Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/onelogin/php-saml/) toolkit, [many other configuration variables can be tweaked](https://github.com/onelogin/php-saml/#settings).
 
+## Sending logs 
+If you use AWS and wish to log SAML attempts on your server, you will need define some environment variables on the server which is hosting your Pressbooks instance.
+### AWS S3
+Define the following envirnoment variables:
+
+ ```
+  LOG_LOGIN_ATTEMPTS (setting this value to true will enable this feature at the infrastructure level)
+  AWS_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY
+  AWS_S3_OIDC_BUCKET
+  AWS_S3_REGION
+  AWS_S3_VERSION
+```
+After these variables have been properly defined, basic information about SAML login attempts will be logged to your S3 bucket. A new CSV file will be created each month so that the logs remain readable. Log storage will take place in a folder structure that looks like this `S3 Bucket > saml_logs > {ENVIRONMENT} > {Network URL hashed though wp_hash function} > {YYYY-MM} > saml_logs.log`.
+
+### AWS CloudWatch Logs
+Define the following envirnoment variables:
+
+ ```
+  LOG_LOGIN_ATTEMPTS (setting this value to true will enable this feature at the infrastructure level)
+  AWS_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY
+  AWS_S3_REGION
+  AWS_S3_VERSION
+```
+After these variables have been properly defined, basic information about SAML login attempts will be logged in your AWS CloudWatch Logs service in JSON format
+
+You will need to create a new Log group called `pressbooks-logs`.
 
 ## Screenshots 
 
@@ -86,14 +114,12 @@ Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/one
 
 ![Metadata XML.](screenshot-2.png)
 
-
 ## Changelog 
 
 ### 1.2.0 
 
 * See: https://github.com/pressbooks/pressbooks-saml-sso/releases/tag/1.2.0
 * Full release history available at: https://github.com/pressbooks/pressbooks-saml-sso/releases
-
 
 ## Upgrade Notice 
 

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -5,6 +5,9 @@ namespace PressbooksSamlSso;
 use function Pressbooks\Utility\empty_space;
 use function Pressbooks\Utility\str_remove_prefix;
 use function Pressbooks\Utility\str_starts_with;
+use Pressbooks\Log\Log;
+use Pressbooks\Log\S3StorageProvider as S3StorageProvider;
+use Pressbooks\Log\CloudWatchProvider as CloudWatchProvider;
 use PressbooksMix\Assets;
 
 /**
@@ -90,12 +93,21 @@ class SAML {
 	private $samlSettings = [];
 
 	/**
+	 * @var Log
+	 */
+	private $log;
+
+	/**
 	 * @return SAML
 	 */
 	static public function init() {
 		if ( is_null( self::$instance ) ) {
 			$admin = Admin::init();
-			self::$instance = new self( $admin );
+			$log = null;
+			if ( CloudWatchProvider::areEnvironmentVariablesPresent() ) {
+				$log = new Log( new CloudWatchProvider() );
+			}
+			self::$instance = new self( $admin, $log );
 			self::hooks( self::$instance );
 		}
 		return self::$instance;
@@ -114,8 +126,9 @@ class SAML {
 
 	/**
 	 * @param Admin $admin
+	 * @param Log $log
 	 */
-	public function __construct( Admin $admin ) {
+	public function __construct( Admin $admin, Log $log = null ) {
 		$options = $admin->getOptions();
 
 		$this->loginUrl = \PressbooksSamlSso\login_url();
@@ -125,6 +138,7 @@ class SAML {
 		$this->forcedRedirection = (bool) $options['forced_redirection'];
 		$this->admin = $admin;
 		$this->options = $options;
+		$this->log = $log;
 		if ( $this->forcedRedirection ) {
 			// TODO:
 			// This hijacks the same logic as seen in the saml plugin.
@@ -339,6 +353,11 @@ class SAML {
 							$attributes = $_SESSION[ self::USER_DATA ];
 							$net_id = $this->getUsernameByAttributes( $attributes );
 							$email = $this->getEmailByAttributes( $attributes, $net_id );
+
+							$this->logData( 'Session data', $_SESSION );
+							$this->logData( "User's email", [ $email ] );
+							$this->logData( "User's net_id", [ $net_id ] );
+
 							remove_filter( 'authenticate', [ $this, 'authenticate' ], 10 ); // Fix infinite loop
 							/**
 							 * @since 0.0.4
@@ -466,6 +485,10 @@ class SAML {
 			if ( $this->auth->getLastErrorReason() ) {
 				$message .= '. Reason: ' . $this->auth->getLastErrorReason();
 			}
+
+			$this->logData( 'Errors from SAML Auth', $errors );
+			$this->logData( 'Last SAML Error Reason', $message );
+
 			throw new \Exception( $message );
 		}
 		if ( ! $this->auth->isAuthenticated() ) {
@@ -636,6 +659,7 @@ class SAML {
 		$user = $this->matchUser( $net_id );
 
 		if ( $user ) {
+			$this->logData( 'Username matched', [ $user->user_login ] );
 			// If a matching user was found, log them in
 			$logged_in = \Pressbooks\Redirect\programmatic_login( $user->user_login );
 			if ( $logged_in === true ) {
@@ -644,6 +668,15 @@ class SAML {
 		} else {
 			$this->associateUser( $net_id, $email );
 		}
+	}
+
+	private function logData( $key, $data ) {
+		if ( ! is_null( $this->log ) ) {
+			$this->log->addRowToData( $key, $data );
+			$this->log->store();
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -799,6 +832,7 @@ class SAML {
 				return;
 			}
 		}
+		$this->logData( 'Username associated', [ $username ] );
 
 		// Registration was successful, the user account was created (or associated), proceed to login the user automatically...
 		// associate the WordPress user account with the now-authenticated third party account:

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -666,7 +666,6 @@ class SAML {
 			$logged_in = \Pressbooks\Redirect\programmatic_login( $user->user_login );
 			if ( $logged_in === true ) {
 				$this->logData( 'Username matched', [ $user->user_login ] );
-				$this->logData( "Cookies after logged [Matched]", [ $_COOKIE ] );
 				$this->logData( 'Session after logged [Matched]', [ $_SESSION ], true );
 				$this->endLogin( __( 'Logged in!', 'pressbooks-saml-sso' ) );
 			}
@@ -847,7 +846,6 @@ class SAML {
 		$logged_in = \Pressbooks\Redirect\programmatic_login( $username );
 		if ( $logged_in === true ) {
 			$this->logData( 'Username associated', [ $username ] );
-			$this->logData( 'Cookies after logged [Associated]', [ $_COOKIE ] );
 			$this->logData( 'Session after logged [Associated]', [ $_SESSION ], true );
 			$this->endLogin( __( 'Registered and logged in!', 'pressbooks-saml-sso' ) );
 		}

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -104,7 +104,7 @@ class SAML {
 			$admin = Admin::init();
 			$log = null;
 			if ( CloudWatchProvider::areEnvironmentVariablesPresent() ) {
-				$log = new Log( new CloudWatchProvider() );
+				$log = new Log( new CloudWatchProvider( 90, 'pressbooks-logs', 'pressbooks-plugin', 'saml-logs' ) );
 			}
 			self::$instance = new self( $admin, $log );
 			self::hooks( self::$instance );

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -5,10 +5,9 @@ namespace PressbooksSamlSso;
 use function Pressbooks\Utility\empty_space;
 use function Pressbooks\Utility\str_remove_prefix;
 use function Pressbooks\Utility\str_starts_with;
-use Pressbooks\Log\Log;
-use Pressbooks\Log\S3StorageProvider as S3StorageProvider;
-use Pressbooks\Log\CloudWatchProvider as CloudWatchProvider;
 use PressbooksMix\Assets;
+use Pressbooks\Log\CloudWatchProvider as CloudWatchProvider;
+use Pressbooks\Log\Log;
 
 /**
  * SAML: Security Assertion Markup Language


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/private/issues/452

We need to collect and review SAML login data to help us analyze specific bug, like: https://github.com/pressbooks/pressbooks-saml-sso/issues/59

We will store SAML information using the new Log module implemented in this PB plugin PR: https://github.com/pressbooks/pressbooks/pull/2104. This PR makes use of the module installed in Pressbooks Plugin. Travis will pass after the Pressbooks PR is approved.