### PR TITLE
Parsing string to array for Cloudwatch logging

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -514,7 +514,7 @@ class SAML {
 			}
 
 			$this->logData( 'Errors from SAML Auth', $errors );
-			$this->logData( 'Last SAML Error Reason', $message, true );
+			$this->logData( 'Last SAML Error Reason', [ $message ], true );
 
 			throw new \Exception( $message );
 		}

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -461,6 +461,11 @@ class SamlTest extends \WP_UnitTestCase {
 		$user = $this->saml->matchUser( $prefix );
 		$this->assertInstanceOf( '\WP_User', $user );
 
+		$this->saml->linkAccount( $user->ID, $email );
+		$user_meta = get_user_meta( $user->ID, \PressbooksSamlSso\SAML::META_KEY );
+		$this->assertContains( $prefix, $user_meta[0] );
+		$this->assertContains( $email, $user_meta[1] );
+
 		// User exists
 		try {
 			$this->saml->handleLoginAttempt( $prefix, $email );


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/private/issues/484

This change parse an string to array to be compatible with the `logData` function which expects an array as a element to log.