### PR TITLE
Return empty array by default for getPartialCookies method

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -715,8 +715,8 @@ class SAML {
 	}
 
 	private function getPartialCookies() {
+		$cookie_info_to_store = [];
 		if ( ! is_null( $this->log ) ) {
-			$cookie_info_to_store = [];
 			foreach ( $_COOKIE as $key => $cookie ) {
 				$value_to_store = false;
 				$key_to_store = false;
@@ -742,8 +742,8 @@ class SAML {
 					$cookie_info_to_store[ $key_to_store ] = $value_to_store;
 				}
 			}
-			return $cookie_info_to_store;
 		}
+		return $cookie_info_to_store;
 	}
 
 	private function logData( string $key, array $data, bool $store = false ) {


### PR DESCRIPTION
This change fixes:
![Screenshot from 2021-06-24 11-25-24](https://user-images.githubusercontent.com/13248424/123424395-c610e380-d58e-11eb-8529-ee6223c2b99d.png)

When the [environment variables](https://github.com/pressbooks/pressbooks-saml-sso#sending-logs) required for the log module are not provided `getPartialCookies` returns void/null, but the `logData` method [expects an array](https://github.com/pressbooks/pressbooks-saml-sso/blob/a662e577f2446ed3e167c7d01b1dfa94a0a4e46c/inc/class-saml.php#L749) when the [cookies are passed as parameters](https://github.com/pressbooks/pressbooks-saml-sso/blob/a662e577f2446ed3e167c7d01b1dfa94a0a4e46c/inc/class-saml.php#L707).
Now `getPartialCookies` will return an empty array by default avoiding this bug when the log module is not enabled. 