### PR TITLE
Sign logoutRequest and specify sessionIndex information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           node -v
           npm install
           npm run install-build-tools
-          npm run build:production
+          npm run build
           export PATH="$HOME/.composer/vendor/bin:$PATH"
           composer install --no-interaction
           composer global require "phpunit/phpunit:7.5.20"

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -661,6 +661,7 @@ class SAML {
 						$_SESSION[ self::AUTH_DATA ]['nameIdSPNameQualifier']
 					);
 					$this->doExit();
+					return true;
 				}
 			}
 		}

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -651,7 +651,7 @@ class SAML {
 			if ( $this->forcedRedirection || ! empty( $_SESSION[ self::USER_DATA ] ) || get_user_meta( $this->currentUserId, self::META_KEY, true ) ) {
 				if ( ! empty( $this->auth->getSLOurl() ) ) {
 					$this->auth->logout(
-						add_query_arg( 'loggedout', true, wp_login_url() ) ,
+						add_query_arg( 'loggedout', true, wp_login_url() ),
 						[],
 						$_SESSION[ self::AUTH_DATA ]['nameId'],
 						$_SESSION[ self::AUTH_DATA ]['sessionIndex'],

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -649,7 +649,7 @@ class SAML {
 	public function logoutRedirect( $redirect_to ) {
 		if ( $this->samlClientIsReady ) {
 			if ( $this->forcedRedirection || ! empty( $_SESSION[ self::USER_DATA ] ) || get_user_meta( $this->currentUserId, self::META_KEY, true ) ) {
-				if ( ! empty( $this->auth->getSLOurl() ) ) {
+				if ( ! empty( $this->auth->getSLOurl() ) && ! empty( $_SESSION[ self::AUTH_DATA ] ) ) {
 					$this->auth->logout(
 						add_query_arg( 'loggedout', true, wp_login_url() ),
 						[],
@@ -660,6 +660,8 @@ class SAML {
 						$_SESSION[ self::AUTH_DATA ]['nameIdNameQualifier'],
 						$_SESSION[ self::AUTH_DATA ]['nameIdSPNameQualifier']
 					);
+					unset( $_SESSION[ self::USER_DATA ] );
+					unset( $_SESSION[ self::AUTH_DATA ] );
 					$this->doExit();
 					return true;
 				}

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -20,6 +20,8 @@ class SAML {
 
 	const USER_DATA = 'pb_saml_user_data';
 
+	const AUTH_DATA = 'pb_saml_auth_data';
+
 	const AUTH_N_REQUEST_ID = 'pb_saml_auth_n_request_id';
 
 	// IMPORTANT: Do not rename to `pb_saml` - kept like this to be compatible with legacy integrations
@@ -245,6 +247,7 @@ class SAML {
 			'wantAssertionsSigned' => true,
 			'wantAssertionsEncrypted' => true,
 			'wantNameIdEncrypted' => false,
+			'logoutRequestSigned' => true,
 		];
 
 		/**
@@ -258,6 +261,7 @@ class SAML {
 		$config['sp']['entityId'] = network_site_url( self::ENTITY_ID, 'https' ); // This ia a URI, not a URL. Spec says it doesn't need to resolve.
 		$config['sp']['assertionConsumerService']['url'] = \PressbooksSamlSso\acs_url();
 		$config['sp']['singleLogoutService']['url'] = \PressbooksSamlSso\sls_url();
+		$config['sp']['singleLogoutService']['binding'] = \OneLogin\Saml2\Constants::BINDING_HTTP_REDIRECT;
 
 		$config['sp']['attributeConsumingService'] = [
 			'serviceName' => 'Pressbooks',
@@ -539,17 +543,32 @@ class SAML {
 
 		// Attributes
 		$attributes = $this->parseAttributeStatement();
+		$this->storeAuthDataInSession();
 
 		// If we made it to here, then no exceptions were thrown, and everything is fine.
 		// Now that the user has a session the SP allows the request to proceed.
 
 		$_SESSION[ self::USER_DATA ] = $attributes;
+
 		$redirect_to = filter_input( INPUT_POST, 'RelayState', FILTER_SANITIZE_URL ); // TODO
 		if ( $redirect_to && \OneLogin\Saml2\Utils::getSelfURL() !== $redirect_to ) {
 			$this->auth->redirectTo( $redirect_to );
 		} else {
 			$this->auth->redirectTo( $this->loginUrl );
 		}
+	}
+
+	private function storeAuthDataInSession() {
+		$_SESSION[ self::AUTH_DATA ] = [
+			'sessionIndex' => $this->auth->getSessionIndex(),
+			'nameId' => $this->auth->getNameId(),
+			'nameFormat' => $this->auth->getNameIdFormat(),
+			'nameIdNameQualifier' => $this->auth->getNameIdNameQualifier(),
+			'nameIdSPNameQualifier' => $this->auth->getNameIdSPNameQualifier(),
+		];
+		$log_auth_data = $_SESSION[ self::AUTH_DATA ];
+		$log_auth_data['sessionIndex'] = substr( $this->auth->getSessionIndex(), 0, 5 );
+		$this->logData( 'Auth SAML data', $log_auth_data );
 	}
 
 	/**
@@ -631,7 +650,16 @@ class SAML {
 		if ( $this->samlClientIsReady ) {
 			if ( $this->forcedRedirection || ! empty( $_SESSION[ self::USER_DATA ] ) || get_user_meta( $this->currentUserId, self::META_KEY, true ) ) {
 				if ( ! empty( $this->auth->getSLOurl() ) ) {
-					$this->auth->logout( add_query_arg( 'loggedout', true, wp_login_url() ) );
+					$this->auth->logout(
+						add_query_arg( 'loggedout', true, wp_login_url() ) ,
+						[],
+						$_SESSION[ self::AUTH_DATA ]['nameId'],
+						$_SESSION[ self::AUTH_DATA ]['sessionIndex'],
+						false,
+						$_SESSION[ self::AUTH_DATA ]['nameFormat'],
+						$_SESSION[ self::AUTH_DATA ]['nameIdNameQualifier'],
+						$_SESSION[ self::AUTH_DATA ]['nameIdSPNameQualifier']
+					);
 					$this->doExit();
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
   "description": "Scaffolding for a Pressbooks plugin.",
   "scripts": {
     "install-build-tools": "npm install --no-save pressbooks-build-tools",
-    "watch": "npm run production -- --watch",
-    "prod": "npm run production",
-    "build:production": "npm run production",
-    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "mix watch",
+    "build": "npm run production",
+    "production": "mix --production",
     "test": "npm run lint",
     "lint": "npm run -s lint:scripts && npm run -s lint:styles",
     "lint:scripts": "cross-env NODE_ENV=development node_modules/eslint/bin/eslint.js \"assets/src/scripts/*.js\"",

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -43,6 +43,22 @@ class SamlTest extends \WP_UnitTestCase {
 		return $stub1;
 	}
 
+	protected function getMockAdminWithForcedRedirection() {
+		$options = $this->getTestOptions();
+		$options['idp_entity_id'] = 'fake entity id';
+		$options['idp_sso_login_url'] = 'https://pressbooks.test';
+		$options['idp_x509_cert'] = 'fake cert';
+		$options['forced_redirection'] = true;
+		$stub1 = $this
+			->getMockBuilder( '\PressbooksSamlSso\Admin' )
+			->getMock();
+		$stub1
+			->method( 'getOptions' )
+			->willReturn( $options );
+
+		return $stub1;
+	}
+
 	protected function getMockAuth() {
 		$stub1 = $this
 			->getMockBuilder( '\OneLogin\Saml2\Auth' )
@@ -51,6 +67,18 @@ class SamlTest extends \WP_UnitTestCase {
 		$stub1
 			->method( 'redirectTo' )
 			->willReturn( null );
+
+		return $stub1;
+	}
+
+	protected function getMockAuthSLO() {
+		$stub1 = $this
+			->getMockBuilder( '\OneLogin\Saml2\Auth' )
+			->disableOriginalConstructor()
+			->getMock();
+		$stub1
+			->method( 'getSLOurl' )
+			->willReturn( 'fake url' );
 
 		return $stub1;
 	}
@@ -437,7 +465,12 @@ class SamlTest extends \WP_UnitTestCase {
 
 	// TODO
 	// test_samlSingleLogoutService
-	// test_logoutRedirect
+
+	public function test_logoutRedirect() {
+		$saml = new \PressbooksSamlSso\SAML( $this->getMockAdminWithForcedRedirection() );
+		$saml->setAuth( $this->getMockAuthSLO() );
+		$this->assertTrue( $saml->logoutRedirect('https://pressbooks.test') );
+	}
 
 	public function test_loginEnqueueScripts() {
 		$this->saml->loginEnqueueScripts();

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -469,6 +469,7 @@ class SamlTest extends \WP_UnitTestCase {
 	public function test_logoutRedirect() {
 		$saml = new \PressbooksSamlSso\SAML( $this->getMockAdminWithForcedRedirection() );
 		$saml->setAuth( $this->getMockAuthSLO() );
+		$_SESSION[ \PressbooksSamlSso\SAML::AUTH_DATA ] = ['fake auth data'];
 		$this->assertTrue( $saml->logoutRedirect('https://pressbooks.test') );
 	}
 

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,7 +1,5 @@
 let mix = require( 'laravel-mix' );
 let path = require( 'path' );
-let normalizeNewline = require( 'normalize-newline' );
-let fs = require( 'fs' );
 
 /*
  |--------------------------------------------------------------------------
@@ -13,20 +11,6 @@ let fs = require( 'fs' );
  | file for your application, as well as bundling up your JS files.
  |
  */
-
-// Normalize Newlines
-const normalizeNewlines = ( dir ) => {
-	fs.readdirSync( dir ).forEach( function( file ) {
-		file = path.join( dir, file );
-		fs.readFile( file, 'utf8', function( err, buffer ) {
-			if ( err ) return console.log( err );
-			buffer = normalizeNewline( buffer );
-			fs.writeFile( file, buffer, 'utf8', function( err ) {
-				if ( err ) return console.log( err );
-			} );
-		} );
-	} );
-};
 
 mix.setPublicPath( path.join( 'assets', 'dist' ) )
 	.version()
@@ -40,35 +24,3 @@ mix.setPublicPath( path.join( 'assets', 'dist' ) )
 		normalizeNewlines( 'assets/dist/scripts/' );
 		normalizeNewlines( 'assets/dist/styles/' );
 	} );
-
-// Full API
-// mix.js(src, output); <-- compile (ES2015 syntax, modules, ...) !and! minify
-// mix.scripts(src, output); <-- just minify
-// mix.react(src, output); <-- Identical to mix.js(), but registers React Babel compilation.
-// mix.extract(vendorLibs);
-// mix.sass(src, output);
-// mix.standaloneSass('src', output); <-- Faster, but isolated from Webpack.
-// mix.fastSass('src', output); <-- Alias for mix.standaloneSass().
-// mix.less(src, output);
-// mix.stylus(src, output);
-// mix.browserSync( 'my-site.dev' );
-// mix.combine(files, destination);
-// mix.babel(files, destination); <-- Identical to mix.combine(), but also includes Babel compilation.
-// mix.copy(from, to);
-// mix.copyDirectory(fromDir, toDir);
-// mix.minify(file);
-// mix.sourceMaps(); // Enable sourcemaps
-// mix.version(); // Enable versioning.
-// mix.disableNotifications();
-// mix.setPublicPath( 'path/to/public' );
-// mix.setResourceRoot( 'prefix/for/resource/locators' );
-// mix.autoload({}); <-- Will be passed to Webpack's ProvidePlugin.
-// mix.webpackConfig({}); <-- Override webpack.config.js, without editing the file directly.
-// mix.then(function () {}) <-- Will be triggered each time Webpack finishes building.
-// mix.options({
-//   extractVueStyles: false, // Extract .vue component styling to file, rather than inline.
-//   processCssUrls: true, // Process/optimize relative stylesheet url()'s. Set to false, if you don't want them touched.
-//   purifyCss: false, // Remove unused CSS selectors.
-//   uglify: {}, // Uglify-specific options. https://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin
-//   postCss: [] // Post-CSS options: https://github.com/postcss/postcss/blob/master/docs/plugins.md
-// });

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -19,8 +19,4 @@ mix.setPublicPath( path.join( 'assets', 'dist' ) )
 	.sass( 'assets/src/styles/pressbooks-saml-sso.scss', 'assets/dist/styles/' )
 	.sass( 'assets/src/styles/login-form.scss', 'assets/dist/styles/' )
 	.copyDirectory( 'assets/src/fonts', 'assets/dist/fonts' )
-	.copyDirectory( 'assets/src/images', 'assets/dist/images' )
-	.then( () => {
-		normalizeNewlines( 'assets/dist/scripts/' );
-		normalizeNewlines( 'assets/dist/styles/' );
-	} );
+	.copyDirectory( 'assets/src/images', 'assets/dist/images' );


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks-saml-sso/issues/49

This fix the IdP logoutRequest action (see specification in: https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf (section 3.7.3.1).

Previously we had this error when logoutRequest is sent:
```
2021-07-01 15:12:06,759 - WARN [org.opensaml.profile.action.impl.LogEvent:?] - A non-proceed event occurred while processing the request: MessageAuthenticationError
2021-07-01 15:12:06,759 - DEBUG [org.opensaml.saml.common.profile.logic.DefaultLocalErrorPredicate:?] - No SAMLBindingContext or binding URI available, error must be handled locally
```

Additionally to the logoutRequest signed, we need to specify sessionIndex and other parameters to be able to identify the session to close, for that reason I am storing that information in the wp user session.

### Test
- If you are using [SAML Test](https://samltest.id/), the correct SingleLogoutService URL is: **https://samltest.id/idp/profile/SAML2/Redirect/SLO**. Make sure it is properly configured in your local environment.
- Log in using SAML
- Log out and make sure the IdP requires you sign in again in any case