### PR TITLE
Add logs for SAML auth data

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -568,7 +568,7 @@ class SAML {
 		];
 		$log_auth_data = $_SESSION[ self::AUTH_DATA ];
 		$log_auth_data['sessionIndex'] = substr( $this->auth->getSessionIndex(), 0, 5 );
-		$this->logData( 'Auth SAML data', $log_auth_data );
+		$this->logData( 'Auth SAML data', $log_auth_data, true );
 	}
 
 	/**


### PR DESCRIPTION
This PR send auth data generated in: https://github.com/pressbooks/pressbooks-saml-sso/pull/77 to CloudWatch to inspect the necessary values for the SLO.