### PR TITLE
ci: use wp-cli-bundle instead of nightly

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -18,13 +18,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.4'
-        tools: composer
-    - name: Install WP CLI
-      run: |
-        curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar
-        chmod +x wp-cli-nightly.phar
-        sudo mv wp-cli-nightly.phar /usr/local/bin/wp
-        wp package install wp-cli/i18n-command
+        tools: composer, wp-cli/wp-cli-bundle
     - name: Update POT file
       run: wp i18n make-pot . languages/pressbooks-saml-sso.pot --domain=pressbooks-saml-sso --slug=pressbooks-saml-sso --package-name="Pressbooks SAML SSO" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-saml-sso/issues\"}"
     # Remove this step once you are satisfied with the results; alternatively, you can leave it in place and remove

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -20,7 +20,7 @@ jobs:
         php-version: '7.4'
         tools: composer, wp-cli/wp-cli-bundle
     - name: Update POT file
-      run: wp i18n make-pot . languages/pressbooks-saml-sso.pot --domain=pressbooks-saml-sso --slug=pressbooks-saml-sso --package-name="Pressbooks SAML SSO" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-saml-sso/issues\"}"
+      run: wp i18n make-pot . languages/pressbooks-saml-sso.pot --domain=pressbooks-saml-sso --slug=pressbooks-saml-sso --package-name="Pressbooks SAML2 Single Sign-On" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-saml-sso/issues\"}"
     # Remove this step once you are satisfied with the results; alternatively, you can leave it in place and remove
     # the commented out step that follows.
     - name: Open PR with changes

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -19,9 +19,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.4'
-        tools: composer, wp-cli
-    - name: Install dependencies
-      run: wp package install wp-cli/i18n-command
+        tools: composer, wp-cli/wp-cli-bundle
     - name: Generate MO files
       run: wp i18n make-mo languages
     # Remove this step once you are satisfied with the results; alternatively, you can leave it in place and remove


### PR DESCRIPTION
This PR is a followup to #123 which uses the WP CLI composer package instead of the nightly build. This means we'll be using stable versions but won't run into the issue encountered prior to #123 where the version of WP CLI bundled an old copy of the i18n command.