### PR TITLE
Don't require AuthContext

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -247,6 +247,7 @@ class SAML {
 			'wantAssertionsEncrypted' => true,
 			'wantNameIdEncrypted' => false,
 			'logoutRequestSigned' => true,
+			'requestedAuthnContext' => false,
 		];
 
 		/**


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks-saml-sso/issues/140. This PR sets requestedAuthnContext to false, as requested by client whose MFA logins failed. See 
![](https://user-images.githubusercontent.com/13485451/192897656-476377cc-f0b0-4bc4-975a-2954db0edb98.png)

Relevant docs in SAML library: 
```
// Authentication context.
        // Set to false and no AuthContext will be sent in the AuthNRequest.
        // Set true or don't present this parameter and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'.
        // Set an array with the possible auth context values: array ('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509').
        'requestedAuthnContext' => false,
```
https://github.com/onelogin/php-saml/blob/master/README.md

Previously, we weren't presenting this parameter, which meant we were only accepting AuthContext `exact` (i.e. `PasswordProtectedTransport`)

To test: I've asked the client who has requested this to allow integrations to access their IdP and to give us a test account that can access Duo MFA. Will update you if that request is granted.
